### PR TITLE
CAN-2003 add readiness probe to stream prediction

### DIFF
--- a/tf-inference-stream/charts/templates/job.yaml
+++ b/tf-inference-stream/charts/templates/job.yaml
@@ -49,6 +49,12 @@ spec:
               name: grpc-port
             - containerPort: {{ .Values.restContainerPort }}
               name: rest-port
+          readinessProbe:
+            httpGet:
+              path: /
+              port: rest-port
+            initialDelaySeconds: 10
+            timeoutSeconds: 300
           volumeMounts:
             - name: input-home
               mountPath: /mnt/input/home


### PR DESCRIPTION
Add readiness probe to streaming prediction instance.

Tests: https://ci.nervana.sclab.intel.com/job/carbon/job/k8s/job/K8sClusterOps-builder01/431/ (one test failed, but it is unrelated to these changes - workspace pods were deleted from required component lists in nauta-test)