### PR TITLE
CAN-2395: Fixed python path for horovod py3

### DIFF
--- a/multinode-tf-training-horovod/charts/templates/job.yaml
+++ b/multinode-tf-training-horovod/charts/templates/job.yaml
@@ -97,7 +97,7 @@ spec:
             {{- range .Values.master.env }} -x {{ .name }} {{- end }}
             --mca orte_keep_fqdn_hostnames t --allow-run-as-root --display-map --tag-output --timestamp-output
             {{- if and .Values.useHostNetwork .Values.hostNetworkInterface }} --mca btl_tcp_if_include {{ .Values.hostNetworkInterface }} {{ else }} --mca btl_tcp_if_exclude lo,docker0 {{- end }}
-            sh -c '/usr/local/bin/python {{- range .Values.commandline.args }} {{ . }} {{- end }}'
+            sh -c 'python {{- range .Values.commandline.args }} {{ . }} {{- end }}'
 {{- if .Values.master.args }}
 {{ toYaml .Values.master.args | indent 10 }}
 {{- end }}


### PR DESCRIPTION
http://nervanastatus.sclab.intel.com:8000/reports/build_number_report?environment=cicd-nauta-ajoskows-2&nervana_build_number=20190722131744

Merge together with: https://github.com/NervanaSystems/nauta/pull/1784 & https://github.com/NervanaSystems/nauta-test/pull/1472